### PR TITLE
CPG-21: fix: skip JIRA issue key check only for develop, main, and re…

### DIFF
--- a/.github/workflows/jira-status.yml
+++ b/.github/workflows/jira-status.yml
@@ -56,6 +56,14 @@ jobs:
         run: |
           if [ "$SAFE_EVENT_NAME" = "pull_request" ]; then
             branch_or_pr="$SAFE_HEAD_REF"
+
+          # Only skip if branch is develop, main, or release/*
+          if [[ "$branch_or_pr" =~ ^(develop|main|release/.*)$ ]]; then
+            echo "Skipping JIRA key check for branch: $branch_or_pr"
+            echo "skip=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
           else
             branch_or_pr="$SAFE_REF_NAME"
           fi

--- a/.github/workflows/jira-status.yml
+++ b/.github/workflows/jira-status.yml
@@ -55,18 +55,17 @@ jobs:
           SAFE_EVENT_NAME: ${{ github.event_name }}
         run: |
           if [ "$SAFE_EVENT_NAME" = "pull_request" ]; then
-            branch_or_pr="$SAFE_HEAD_REF"
-
-          # Only skip if branch is develop, main, or release/*
-          if [[ "$branch_or_pr" =~ ^(develop|main|release/.*)$ ]]; then
-            echo "Skipping JIRA key check for branch: $branch_or_pr"
-            echo "skip=true" >> $GITHUB_OUTPUT
-            exit 0
-          fi
-
+branch_or_pr="$SAFE_HEAD_REF"
           else
-            branch_or_pr="$SAFE_REF_NAME"
+branch_or_pr="$SAFE_REF_NAME"
           fi
+
+# Skip JIRA key check for long-lived branches
+if [[ "$branch_or_pr" =~ ^(develop|main|release/.*)$ ]]; then
+  echo "Skipping JIRA key check for branch: $branch_or_pr"
+  echo "skip=true" >> $GITHUB_OUTPUT
+  exit 0
+fi
 
           issue_key=$(echo "$branch_or_pr" | grep -oE '[A-Z]+-[0-9]+')
 

--- a/.github/workflows/jira-status.yml
+++ b/.github/workflows/jira-status.yml
@@ -38,15 +38,15 @@ jobs:
           action="$SAFE_ACTION"
           merged="$SAFE_PR_MERGED"
 
-          if [ "$event" = "push" ] && echo "$branch" | grep -qE '^(feature|bugfix|hotfix)/'; then
+          if [ "$event" = "push" ] && echo "$branch" | grep -qE '^(feature|bug          fix|hot          fix)/'; then
             transition_id="21"  # In Progress
           elif [ "$event" = "pull_request" ] && [ "$action" = "opened" ]; then
             transition_id="31"  # In Review
           elif [ "$event" = "pull_request" ] && [ "$action" = "closed" ] && [ "$merged" = "true" ]; then
             transition_id="41"  # Done
-          fi
+                    fi
 
-          echo "transition_id=$transition_id" >> $GITHUB_OUTPUT
+                    echo "transition_id=$transition_id" >> $GITHUB_OUTPUT
       - name: Extract JIRA issue key
         id: extract
         env:
@@ -55,28 +55,28 @@ jobs:
           SAFE_EVENT_NAME: ${{ github.event_name }}
         run: |
           if [ "$SAFE_EVENT_NAME" = "pull_request" ]; then
-branch_or_pr="$SAFE_HEAD_REF"
+          branch_or_pr="$SAFE_HEAD_REF"
           else
-branch_or_pr="$SAFE_REF_NAME"
-          fi
+          branch_or_pr="$SAFE_REF_NAME"
+                    fi
 
 # Skip JIRA key check for long-lived branches
-if [[ "$branch_or_pr" =~ ^(develop|main|release/.*)$ ]]; then
-  echo "Skipping JIRA key check for branch: $branch_or_pr"
-  echo "skip=true" >> $GITHUB_OUTPUT
-  exit 0
-fi
-
-          issue_key=$(echo "$branch_or_pr" | grep -oE '[A-Z]+-[0-9]+')
-
-          if [ -z "$issue_key" ]; then
-            echo "No JIRA issue key found in branch or PR name. Skipping."
+          if [[ "$branch_or_pr" =~ ^(develop|main|release/.*)$ ]]; then
+            echo "Skipping JIRA key check for branch: $branch_or_pr"
             echo "skip=true" >> $GITHUB_OUTPUT
             exit 0
           fi
 
-          echo "Found JIRA issue key: $issue_key"
-          echo "issue_key=$issue_key" >> $GITHUB_OUTPUT
+          issue_key=$(echo "$branch_or_pr" | grep -oE '[A-Z]+-[0-9]+')
+
+          if [ -z "$issue_key" ]; then
+                      echo "No JIRA issue key found in branch or PR name. Skipping."
+                      echo "skip=true" >> $GITHUB_OUTPUT
+                      exit 0
+                    fi
+
+                    echo "Found JIRA issue key: $issue_key"
+                    echo "issue_key=$issue_key" >> $GITHUB_OUTPUT
       - name: Update JIRA issue
         if: steps.extract.outputs.skip != 'true' && steps.determine.outputs.transition_id != ''
         run: |


### PR DESCRIPTION
…lease/*

- Updated `jira-status.yml` to only skip the JIRA issue check when the branch is develop, main, or matches release/*
- Branches like feature/*, bugfix/*, and hotfix/* now require a valid JIRA issue key in the name
- Prevents unintended skips and enforces JIRA linkage for all work branches

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved workflow to skip JIRA key checks for "develop", "main", and "release/*" branches, reducing unnecessary processing for these branches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->